### PR TITLE
SEC-94 internalising used githubactions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -17,7 +17,7 @@ jobs:
           docker build . -t auto1/test-data-storage-ui:latest -f ./Dockerfile
 
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: auto1-oss/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
This PR updates GitHub Action references to use internal versions from the auto1-oss organization.